### PR TITLE
Expose api version

### DIFF
--- a/web/viewer.js
+++ b/web/viewer.js
@@ -33,6 +33,7 @@ const AppConstants =
 window.PDFViewerApplication = PDFViewerApplication;
 window.PDFViewerApplicationConstants = AppConstants;
 window.PDFViewerApplicationOptions = AppOptions;
+window.PDFViewerApiVersion = pdfjsVersion;
 
 function getViewerConfiguration() {
   return {


### PR DESCRIPTION
This exposes api version so we can add query parameter with version when referencing pdf.worker.mjs file from the app.

I tried to add version to the name of both pdf.mjs and pdf.worker.mjs files, but the problem is those files are referenced from viewer.html file, and we would need to somehow update automatically those links so they point to correct file name with version.
I looked into using HTMLWebpackPlugin, but it would complicate things, as we would need to define our custom template, and I'm not sure if it's worth the effort. Also, pdf.worker.mjs file is referenced from pdf.mjs file, so again we would need to update links somehow there (actually, we could reference file from the app, as we will do with query parameter, but it's not ideal). 

Because of all this, adding query parameter seems like more appropriate solution at the moment.