### PR TITLE
Fix some exploitable parts

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -638,7 +638,7 @@ const PDFViewerApplication = {
     let file;
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
       file = AppOptions.get("defaultUrl");
-      // validateFileURL(file);
+      validateFileURL(file);
     } else if (PDFJSDev.test("MOZCENTRAL")) {
       file = window.location.href;
     } else if (PDFJSDev.test("CHROME")) {
@@ -2137,9 +2137,19 @@ if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
     if (!file) {
       return;
     }
+    const ALLOWED_FILE_ORIIGNS = [
+      "https://files.pumble.com", // PROD
+      "https://files.stage.ops.pumble.com", // STAGE
+      "https://files.fe.pumble-dev.com", // DEV
+    ];
+
     try {
       const viewerOrigin = new URL(window.location.href).origin || "null";
       const fileOrigin = new URL(file, window.location.href).origin;
+
+      if (ALLOWED_FILE_ORIIGNS.includes(fileOrigin)) {
+        return;
+      }
       // Removing of the following line will not guarantee that the viewer will
       // start accepting URLs from foreign origin -- CORS headers on the remote
       // server must be properly configured.

--- a/web/app.js
+++ b/web/app.js
@@ -177,6 +177,7 @@ const PDFViewerApplication = {
   _nimbusDataPromise: null,
   _caretBrowsing: null,
   _isScrolling: false,
+  _failedToLoad: false,
 
   // Called once when the document is loaded.
   async initialize(appConfig) {
@@ -1027,6 +1028,7 @@ const PDFViewerApplication = {
         } else if (reason instanceof UnexpectedResponseException) {
           key = "pdfjs-unexpected-response-error";
         }
+
         return this._documentError(key, { message: reason.message }).then(
           () => {
             throw reason;
@@ -1059,6 +1061,9 @@ const PDFViewerApplication = {
     } catch {
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply download using the URL.
+      if (this._failedToLoad) {
+        return;
+      }
       await this.downloadManager.downloadUrl(url, filename, options);
     }
   },
@@ -1119,6 +1124,8 @@ const PDFViewerApplication = {
       key || "pdfjs-loading-error",
       moreInfo
     );
+
+    this._failedToLoad = true;
 
     this.eventBus.dispatch("documenterror", {
       source: this,

--- a/web/app.js
+++ b/web/app.js
@@ -637,10 +637,8 @@ const PDFViewerApplication = {
     const { appConfig, eventBus } = this;
     let file;
     if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-      const queryString = document.location.search.substring(1);
-      const params = parseQueryString(queryString);
-      file = params.get("file") ?? AppOptions.get("defaultUrl");
-      validateFileURL(file, true);
+      file = AppOptions.get("defaultUrl");
+      // validateFileURL(file);
     } else if (PDFJSDev.test("MOZCENTRAL")) {
       file = window.location.href;
     } else if (PDFJSDev.test("CHROME")) {
@@ -1062,7 +1060,6 @@ const PDFViewerApplication = {
       if (this._failedToLoad) {
         return;
       }
-
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply download using the URL.
       await this.downloadManager.downloadUrl(url, filename, options);
@@ -2135,21 +2132,13 @@ if (typeof PDFJSDev === "undefined" || !PDFJSDev.test("MOZCENTRAL")) {
 }
 
 if (typeof PDFJSDev === "undefined" || PDFJSDev.test("GENERIC")) {
-  const HOSTED_VIEWER_ORIGINS = ["null"];
   // eslint-disable-next-line no-var
-  var validateFileURL = function (file, forceNullHostedViewOrigin = false) {
+  var validateFileURL = function (file) {
     if (!file) {
       return;
     }
     try {
       const viewerOrigin = new URL(window.location.href).origin || "null";
-      if (
-        HOSTED_VIEWER_ORIGINS.includes(viewerOrigin) ||
-        forceNullHostedViewOrigin
-      ) {
-        // Hosted or local viewer, allow for any file locations
-        return;
-      }
       const fileOrigin = new URL(file, window.location.href).origin;
       // Removing of the following line will not guarantee that the viewer will
       // start accepting URLs from foreign origin -- CORS headers on the remote

--- a/web/app.js
+++ b/web/app.js
@@ -1059,11 +1059,12 @@ const PDFViewerApplication = {
 
       await this.downloadManager.download(blob, url, filename, options);
     } catch {
-      // When the PDF document isn't ready, or the PDF file is still
-      // downloading, simply download using the URL.
       if (this._failedToLoad) {
         return;
       }
+
+      // When the PDF document isn't ready, or the PDF file is still
+      // downloading, simply download using the URL.
       await this.downloadManager.downloadUrl(url, filename, options);
     }
   },

--- a/web/app.js
+++ b/web/app.js
@@ -177,7 +177,6 @@ const PDFViewerApplication = {
   _nimbusDataPromise: null,
   _caretBrowsing: null,
   _isScrolling: false,
-  _failedToLoad: false,
 
   // Called once when the document is loaded.
   async initialize(appConfig) {
@@ -1057,9 +1056,6 @@ const PDFViewerApplication = {
 
       await this.downloadManager.download(blob, url, filename, options);
     } catch {
-      if (this._failedToLoad) {
-        return;
-      }
       // When the PDF document isn't ready, or the PDF file is still
       // downloading, simply download using the URL.
       await this.downloadManager.downloadUrl(url, filename, options);
@@ -1122,8 +1118,6 @@ const PDFViewerApplication = {
       key || "pdfjs-loading-error",
       moreInfo
     );
-
-    this._failedToLoad = true;
 
     this.eventBus.dispatch("documenterror", {
       source: this,

--- a/web/download_manager.js
+++ b/web/download_manager.js
@@ -24,24 +24,27 @@ if (typeof PDFJSDev !== "undefined" && !PDFJSDev.test("CHROME || GENERIC")) {
   );
 }
 
-function download(blobUrl, filename) {
-  const a = document.createElement("a");
-  if (!a.click) {
-    throw new Error('DownloadManager: "a.click()" is not supported.');
-  }
-  a.href = blobUrl;
-  a.target = "_parent";
-  // Use a.download if available. This increases the likelihood that
-  // the file is downloaded instead of opened by another PDF plugin.
-  if ("download" in a) {
-    a.download = filename;
-  }
-  // <a> must be in the document for recent Firefox versions,
-  // otherwise .click() is ignored.
-  (document.body || document.documentElement).append(a);
-  a.click();
-  a.remove();
-}
+// Original function - not used as we don't want to download anything via pdfjs
+// function downloadOriginal(blobUrl, filename) {
+//   const a = document.createElement("a");
+//   if (!a.click) {
+//     throw new Error('DownloadManager: "a.click()" is not supported.');
+//   }
+//   a.href = blobUrl;
+//   a.target = "_parent";
+//   // Use a.download if available. This increases the likelihood that
+//   // the file is downloaded instead of opened by another PDF plugin.
+//   if ("download" in a) {
+//     a.download = filename;
+//   }
+//   // <a> must be in the document for recent Firefox versions,
+//   // otherwise .click() is ignored.
+//   (document.body || document.documentElement).append(a);
+//   a.click();
+//   a.remove();
+// }
+
+function download(blobUrl, filename) {}
 
 /**
  * @implements {IDownloadManager}

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -60,7 +60,8 @@ class Toolbar {
       { element: options.zoomIn, eventName: "zoomin" },
       { element: options.zoomOut, eventName: "zoomout" },
       { element: options.print, eventName: "print" },
-      { element: options.download, eventName: "download" },
+      // We don't want to download anything via pdfjs
+      // { element: options.download, eventName: "download" },
       {
         element: options.editorFreeTextButton,
         eventName: "switchannotationeditormode",

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -370,14 +370,15 @@ See https://github.com/adobe-type-tools/cmap-resources
                 </div>
 
                 <div id="editorModeSeparator" class="verticalToolbarSeparator"></div>
-
+  
                 <button id="print" class="toolbarButton hiddenMediumView" title="Print" tabindex="41" data-l10n-id="pdfjs-print-button">
                   <span data-l10n-id="pdfjs-print-button-label">Print</span>
                 </button>
 
-                <button id="download" class="toolbarButton hiddenMediumView" title="Save" tabindex="42" data-l10n-id="pdfjs-save-button">
+                <!-- We don't want to render this button on webclient -->
+                <!-- <button id="download" class="toolbarButton hiddenMediumView" title="Save" tabindex="42" data-l10n-id="pdfjs-save-button">
                   <span data-l10n-id="pdfjs-save-button-label">Save</span>
-                </button>
+                </button> -->
 
                 <div class="verticalToolbarSeparator hiddenMediumView"></div>
 


### PR DESCRIPTION
Potential fix for vulnerability. We couldn't comment download function from downloadManager as it would break our download.

Edit* Following the agreement next is done:

- Remove download button from the viewer
- Core download function is now noop, just to make sure we don't use original download function
- File can not be provided via query parameter. It can only be done via app options
- Allowed list of file services is introduced